### PR TITLE
Clarify API's requests exceptions

### DIFF
--- a/pynsee/utils/_request_insee.py
+++ b/pynsee/utils/_request_insee.py
@@ -9,6 +9,21 @@ from pynsee.utils._get_token import _get_token
 from pynsee.utils._get_credentials import _get_credentials
 from pynsee.utils._wait_api_query_limit import _wait_api_query_limit
 
+CODES = {
+    # 200:"Opération réussie",
+    # 301:"Moved Permanently" -> r.headers['location']
+    400:"Bad Request",
+    401:"Unauthorized : token missing",
+    403:"Forbidden : missing subscription to API", #
+    404:"Not Found : no results available",
+    406:"Not acceptable : incorrect 'Accept' header",
+    413:"Too many results, query must be splitted",
+    414:"Request-URI Too Long",
+    429:"Too Many Requests : allocated quota overloaded",
+    500:"Internal Server Error ",
+    503:"Service Unavailable",
+    }
+
 
 def _request_insee(
     api_url=None, sdmx_url=None, file_format="application/xml", print_msg=True
@@ -73,11 +88,15 @@ def _request_insee(
 
             success = True
 
+            code = results.status_code
+            
             if "status_code" not in dir(results):
                 success = False
-            else:
-                if results.status_code != 200:
-                    success = False
+            elif code in CODES:
+                msg = f"Error {code} - {CODES[code]}"
+                raise requests.exceptions.RequestException(msg)
+            elif code != 200:
+                success = False
 
             if success is True:
                 return results


### PR DESCRIPTION
Added detailed responses about the APIs responses codes.

I checked the documentation of all current APIs, but there may be some return codes which have not been documented in the swagger. For instance, the SIRENE API's doc mentions 301 codes for permanently moved companies ; I haven't seen those responses while scrolling through the swagger (and I haven't checked if requests handles the redirection by itself as I have no concrete example to test it).

I changed the class of errors returned when encountering the 40X & 50X errors. I think 'ValueError' was an awkward choice (regarding to the large explanations about those errors). I choose instead a generic "requests.exceptions.RequestException which is more neutral (I think...).


(I maintained the previous error messages/classes  in the case of the APIs returning any other code than those expressly stated.)